### PR TITLE
feat(followership): allow users to follow each other

### DIFF
--- a/backend/lib/backend/followerships.ex
+++ b/backend/lib/backend/followerships.ex
@@ -1,0 +1,142 @@
+defmodule Backend.Followerships do
+  @moduledoc """
+  The Followerships context.
+  """
+
+  import Ecto.Query, warn: false
+  alias Backend.Repo
+
+  alias Backend.Accounts.User
+  alias Backend.Followerships.Followership
+
+  @doc """
+  Returns the list of followerships.
+
+  ## Examples
+
+      iex> list_followerships()
+      [%Followership{}, ...]
+
+  """
+  def list_followerships do
+    Followership
+    |> Repo.all()
+    |> Repo.preload([:follower, :followee])
+  end
+
+  @doc """
+  Gets a single followership.
+
+  Raises `Ecto.NoResultsError` if the Followership does not exist.
+
+  ## Examples
+
+      iex> get_followership!(123)
+      %Followership{}
+
+      iex> get_followership!(456)
+      ** (Ecto.NoResultsError)
+
+  """
+  def get_followership!(id),
+    do: Repo.get!(Followership, id) |> Repo.preload([:follower, :followee])
+
+  @doc """
+  Creates a followership.
+
+  ## Examples
+
+      iex> create_followership(%{field: value})
+      {:ok, %Followership{}}
+
+      iex> create_followership(%{field: bad_value})
+      {:error, %Ecto.Changeset{}}
+
+  """
+  def create_followership(attrs \\ %{}) do
+    %Followership{}
+    |> Followership.changeset(attrs)
+    |> Repo.insert()
+  end
+
+  @doc """
+  Updates a followership.
+
+  ## Examples
+
+      iex> update_followership(followership, %{field: new_value})
+      {:ok, %Followership{}}
+
+      iex> update_followership(followership, %{field: bad_value})
+      {:error, %Ecto.Changeset{}}
+
+  """
+  def update_followership(%Followership{} = followership, attrs) do
+    followership
+    |> Followership.changeset(attrs)
+    |> Repo.update()
+  end
+
+  @doc """
+  List Users followers
+
+  ## Example
+  iex> followers(%User{} = user)
+  [%Followership{}]
+  """
+  def followers(%User{} = user) do
+    from(f in Followership,
+      where: f.followee_id == ^user.id,
+      join: u in assoc(f, :follower),
+      preload: [follower: u],
+      select: f
+    )
+    |> Repo.all()
+  end
+
+  @doc """
+  List Users a User follows
+
+  ## Example
+  iex> following(%User{} = user)
+  [%Followership{}]
+  """
+  def following(%User{} = user) do
+    from(f in Followership,
+      where: f.follower_id == ^user.id,
+      join: u in assoc(f, :followee),
+      preload: [followee: u],
+      select: f
+    )
+    |> Repo.all()
+  end
+
+  @doc """
+  Deletes a followership.
+
+  ## Examples
+
+      iex> delete_followership(followership)
+      {:ok, %Followership{}}
+
+      iex> delete_followership(followership)
+      {:error, %Ecto.Changeset{}}
+
+  """
+  def delete_followership(%Followership{} = followership) do
+    Repo.delete(followership)
+  end
+
+  @doc """
+  Returns an `%Ecto.Changeset{}` for tracking followership changes.
+
+  ## Examples
+
+      iex> change_followership(followership)
+      %Ecto.Changeset{data: %Followership{}}
+
+  """
+  def change_followership(%Followership{} = followership, attrs \\ %{}) do
+    Followership.changeset(followership, attrs)
+  end
+end

--- a/backend/lib/backend/followerships/followership.ex
+++ b/backend/lib/backend/followerships/followership.ex
@@ -1,0 +1,20 @@
+defmodule Backend.Followerships.Followership do
+  use Ecto.Schema
+  import Ecto.Changeset
+
+  schema "followerships" do
+    belongs_to :follower, Backend.Accounts.User, foreign_key: :follower_id
+    belongs_to :followee, Backend.Accounts.User, foreign_key: :followee_id
+
+    timestamps(type: :utc_datetime)
+  end
+
+  @doc false
+  def changeset(followership, attrs) do
+    followership
+    |> cast(attrs, [:follower_id, :followee_id])
+    |> validate_required([:follower_id, :followee_id])
+    |> assoc_constraint(:follower)
+    |> assoc_constraint(:followee)
+  end
+end

--- a/backend/lib/backend_web/controllers/followership_controller.ex
+++ b/backend/lib/backend_web/controllers/followership_controller.ex
@@ -1,0 +1,51 @@
+defmodule BackendWeb.FollowershipController do
+  use BackendWeb, :controller
+
+  alias BackendWeb.Policies.FollowershipsPolicy
+  alias Backend.Followerships
+  alias Backend.Followerships.Followership
+
+  action_fallback BackendWeb.FallbackController
+
+  def create(conn, %{"followership" => followership_params}) do
+    current_user = Guardian.Plug.current_resource(conn)
+    followee_id = Map.get(followership_params, "followee_id")
+
+    params =
+      Map.merge(followership_params, %{
+        "followee_id" => followee_id,
+        "follower_id" => current_user.id
+      })
+
+    FollowershipsPolicy.create(conn, current_user.id, followee_id)
+
+    with {:ok, %Followership{} = followership} <- Followerships.create_followership(params) do
+      conn
+      |> put_status(:created)
+      |> render(:show, followership: followership)
+    end
+  end
+
+  def followers(conn, _params) do
+    current_user = Guardian.Plug.current_resource(conn)
+
+    followers = Followerships.followers(current_user)
+    render(conn, :index, followerships: followers, assoc: :followers)
+  end
+
+  def following(conn, _params) do
+    current_user = Guardian.Plug.current_resource(conn)
+
+    users_following = Followerships.following(current_user)
+
+    render(conn, :index, followerships: users_following, assoc: :following)
+  end
+
+  def delete(conn, %{"id" => id}) do
+    followership = Followerships.get_followership!(id)
+
+    with {:ok, %Followership{}} <- Followerships.delete_followership(followership) do
+      send_resp(conn, :no_content, "")
+    end
+  end
+end

--- a/backend/lib/backend_web/controllers/followership_json.ex
+++ b/backend/lib/backend_web/controllers/followership_json.ex
@@ -1,0 +1,55 @@
+defmodule BackendWeb.FollowershipJSON do
+  alias BackendWeb.UserJSON
+  alias Backend.Followerships.Followership
+
+  @doc """
+  Renders a list of followerships.
+  """
+  def index(%{followerships: followerships}) do
+    %{data: for(followership <- followerships, do: data(followership))}
+  end
+
+  def index(%{followership: followerships, assoc: assoc}) do
+    %{data: for(followership <- followerships, do: assoc_data(followership, assoc))}
+  end
+
+  @doc """
+  Renders a single followership.
+  """
+  def show(%{followership: followership}) do
+    %{data: data(followership)}
+  end
+
+  defp data(%Followership{} = followership) do
+    %{
+      id: followership.id,
+      follower_id: followership.follower_id,
+      followee_id: followership.followee_id
+    }
+  end
+
+  defp assoc_data(%Followership{} = followership, assoc: assoc) do
+    case assoc do
+      :followers ->
+        %{
+          id: followership.id,
+          follower_id: followership.follower_id,
+          follower: UserJSON.show(%{user: followership.follower}).data,
+          followee_id: followership.followee_id,
+          inserted_at: followership.inserted_at
+        }
+
+      :following ->
+        %{
+          id: followership.id,
+          follower_id: followership.follower_id,
+          followee_id: followership.followee_id,
+          followee: UserJSON.show(%{user: followership.followee}).data,
+          inserted_at: followership.inserted_at
+        }
+
+      nil ->
+        data(followership)
+    end
+  end
+end

--- a/backend/lib/backend_web/policies/followerships_policy.ex
+++ b/backend/lib/backend_web/policies/followerships_policy.ex
@@ -1,0 +1,20 @@
+defmodule BackendWeb.Policies.FollowershipsPolicy do
+  alias Backend.Followerships.Followership
+  alias BackendWeb.ErrorResponse
+
+  def create(conn, user_id, follower_id) do
+    if user_id == follower_id do
+      raise ErrorResponse.BadRequest
+    else
+      conn
+    end
+  end
+
+  def delete(conn, %Followership{} = followership, user_id) do
+    if followership.follower_id == user_id do
+      conn
+    else
+      raise ErrorResponse.BadRequest
+    end
+  end
+end

--- a/backend/lib/backend_web/router.ex
+++ b/backend/lib/backend_web/router.ex
@@ -42,6 +42,10 @@ defmodule BackendWeb.Router do
     get "/friendships/requests", FriendshipController, :friend_requests
     delete "/friendships/:id", FriendshipController, :delete
     get "/friends", FriendshipController, :index
+
+    resources "/followerships", FollowershipController, only: [:index, :create, :delete]
+    get "/followerships/followers", FollowershipController, :followers
+    get "/followerships/following", FollowershipController, :following
   end
 
   # Enable LiveDashboard and Swoosh mailbox preview in development

--- a/backend/priv/repo/migrations/20250701163711_create_followerships.exs
+++ b/backend/priv/repo/migrations/20250701163711_create_followerships.exs
@@ -1,0 +1,15 @@
+defmodule Backend.Repo.Migrations.CreateFollowerships do
+  use Ecto.Migration
+
+  def change do
+    create table(:followerships) do
+      add :follower_id, references(:users, on_delete: :nothing), null: false
+      add :followee_id, references(:users, on_delete: :nothing), null: false
+
+      timestamps(type: :utc_datetime)
+    end
+
+    create index(:followerships, [:follower_id])
+    create index(:followerships, [:followee_id])
+  end
+end

--- a/backend/test/backend/followerships_test.exs
+++ b/backend/test/backend/followerships_test.exs
@@ -1,0 +1,102 @@
+defmodule Backend.FollowershipsTest do
+  use Backend.DataCase
+
+  alias Backend.Followerships
+  alias Backend.Followerships.Followership
+
+  import Backend.FollowershipsFixtures
+  import Backend.AccountsFixtures, only: [user_fixture: 0]
+
+  @invalid_attrs %{follower_id: nil, followee_id: nil}
+
+  describe "list_followerships/0 & get_followership!/1" do
+    test "return all followerships and fetch by id" do
+      fs = followership_fixture()
+      assert Followerships.list_followerships() == [fs]
+      assert Followerships.get_followership!(fs.id) == fs
+    end
+  end
+
+  describe "create_followership/1" do
+    test "with valid data persists the record" do
+      attrs = valid_attrs()
+      assert {:ok, %Followership{} = fs} = Followerships.create_followership(attrs)
+      assert fs.follower_id == attrs.follower_id
+      assert fs.followee_id == attrs.followee_id
+    end
+
+    test "with invalid data returns error changeset" do
+      assert {:error, %Ecto.Changeset{}} =
+               Followerships.create_followership(@invalid_attrs)
+    end
+  end
+
+  describe "update_followership/2" do
+    test "with valid data updates the record" do
+      fs = followership_fixture()
+      new_followee = user_fixture()
+
+      assert {:ok, %Followership{} = updated} =
+               Followerships.update_followership(fs, %{followee_id: new_followee.id})
+
+      assert updated.followee_id == new_followee.id
+    end
+
+    test "with invalid data returns error and record is unchanged" do
+      fs = followership_fixture()
+      assert {:error, _} = Followerships.update_followership(fs, @invalid_attrs)
+      assert fs == Followerships.get_followership!(fs.id)
+    end
+  end
+
+  describe "delete_followership/1" do
+    test "removes the record" do
+      fs = followership_fixture()
+      assert {:ok, %Followership{}} = Followerships.delete_followership(fs)
+      assert_raise Ecto.NoResultsError, fn -> Followerships.get_followership!(fs.id) end
+    end
+  end
+
+  describe "change_followership/2" do
+    test "returns a changeset" do
+      fs = followership_fixture()
+      assert %Ecto.Changeset{} = Followerships.change_followership(fs)
+    end
+  end
+
+  describe "followers/1" do
+    test "returns all users following the given user, preloaded" do
+      followee = user_fixture()
+      f1 = user_fixture()
+      f2 = user_fixture()
+
+      fs1 = followership_fixture(%{follower: f1, followee: followee})
+      fs2 = followership_fixture(%{follower: f2, followee: followee})
+
+      followers = Followerships.followers(followee)
+
+      assert Enum.map(followers, & &1.id) |> Enum.sort() ==
+               Enum.map([fs1, fs2], & &1.id) |> Enum.sort()
+
+      assert Enum.all?(followers, &Ecto.assoc_loaded?(&1.follower))
+    end
+  end
+
+  describe "following/1" do
+    test "returns all users the given user follows, preloaded" do
+      follower = user_fixture()
+      fe1 = user_fixture()
+      fe2 = user_fixture()
+
+      fs1 = followership_fixture(%{follower: follower, followee: fe1})
+      fs2 = followership_fixture(%{follower: follower, followee: fe2})
+
+      following = Followerships.following(follower)
+
+      assert Enum.map(following, & &1.id) |> Enum.sort() ==
+               Enum.map([fs1, fs2], & &1.id) |> Enum.sort()
+
+      assert Enum.all?(following, &Ecto.assoc_loaded?(&1.followee))
+    end
+  end
+end

--- a/backend/test/backend_web/controllers/followership_controller_test.exs
+++ b/backend/test/backend_web/controllers/followership_controller_test.exs
@@ -1,0 +1,87 @@
+defmodule BackendWeb.FollowershipControllerTest do
+  use BackendWeb.ConnCase
+
+  import Backend.FollowershipsFixtures
+  import Backend.Guardian
+
+  alias Backend.AccountsFixtures
+
+  @invalid_attrs %{
+    follower_id: nil
+  }
+
+  setup %{conn: conn} do
+    user = AccountsFixtures.user_fixture()
+    user2 = AccountsFixtures.user_fixture()
+    {:ok, token, _claims} = encode_and_sign(user)
+    {:ok, conn: put_req_header(conn, "accept", "application/json")}
+    %{conn: conn, user: user, token: token, user2: user2}
+  end
+
+  describe "create followership" do
+    test "renders followership when data is valid", %{conn: conn, user2: user2, token: token} do
+      params = %{followee_id: user2.id}
+
+      conn =
+        conn
+        |> put_req_header("authorization", "Bearer #{token}")
+        |> post("/api/followerships", followership: params)
+
+      assert json_response(conn, 201)["data"]
+    end
+
+    test "renders errors when data is invalid", %{conn: conn, token: token} do
+      conn =
+        conn
+        |> put_req_header("authorization", "Bearer #{token}")
+        |> post(~p"/api/followerships", followership: @invalid_attrs)
+
+      assert json_response(conn, 422)["errors"] != %{}
+    end
+  end
+
+  describe "followers" do
+    test "list user followers", %{conn: conn, token: token} do
+      conn =
+        conn
+        |> put_req_header("authorization", "bearer #{token}")
+        |> get("/api/followerships/followers")
+
+      assert json_response(conn, 200)["data"]
+    end
+  end
+
+  describe "following" do
+    test "retrieve followership where user is following", %{conn: conn, token: token} do
+      conn =
+        conn
+        |> put_req_header("authorization", "bearer #{token}")
+        |> get("/api/followerships/following")
+
+      assert json_response(conn, 200)["data"]
+    end
+  end
+
+  describe "delete followership" do
+    setup %{user: user, user2: user2} do
+      %{followership: followership} =
+        create_followership(%{follower_id: user.id, followee_id: user2.id})
+
+      %{followership: followership}
+    end
+
+    test "deletes chosen followership", %{conn: conn, followership: followership, token: token} do
+      conn =
+        conn
+        |> put_req_header("authorization", "Bearer #{token}")
+        |> delete(~p"/api/followerships/#{followership}")
+
+      assert response(conn, 204)
+    end
+  end
+
+  defp create_followership(attrs) do
+    followership = followership_fixture(attrs)
+    %{followership: followership}
+  end
+end

--- a/backend/test/support/fixtures/followerships_fixtures.ex
+++ b/backend/test/support/fixtures/followerships_fixtures.ex
@@ -1,0 +1,37 @@
+defmodule Backend.FollowershipsFixtures do
+  @moduledoc """
+  This module defines test helpers for creating
+  entities via the `Backend.Followerships` context.
+  """
+
+  alias Backend.{Followerships, Repo}
+  alias Backend.AccountsFixtures
+
+  @doc """
+  Returns a valid attribute map for building a followership.
+  Pass in `%{follower: %User{}, followee: %User{}}` if you want
+  to control the pair explicitly.
+  """
+  def valid_attrs(extra \\ %{}) do
+    follower = Map.get(extra, :follower) || AccountsFixtures.user_fixture()
+    followee = Map.get(extra, :followee) || AccountsFixtures.user_fixture()
+
+    %{
+      follower_id: follower.id,
+      followee_id: followee.id
+    }
+  end
+
+  @doc """
+  Creates and returns a persisted `%Followership{}`.
+  Accepts the same optional map as `valid_attrs/1`.
+  """
+  def followership_fixture(attrs \\ %{}) do
+    {:ok, followership} =
+      attrs
+      |> valid_attrs()
+      |> Followerships.create_followership()
+
+    Repo.preload(followership, [:follower, :followee])
+  end
+end


### PR DESCRIPTION
- add migration `create_followerships` with follower_id/followee_id indexes
- define Followership schema + associations on User
- implement create/0, delete/0, followers/1, following/1
- expose POST /api/followerships, GET /api/followerships/followers, GET /api/followerships/following and DELETE /api/followerships/:id
- controller tests for create, delete, followers, following